### PR TITLE
Endpoint get programaciones

### DIFF
--- a/src/main/kotlin/com/estonianport/unique/controller/PiscinaController.kt
+++ b/src/main/kotlin/com/estonianport/unique/controller/PiscinaController.kt
@@ -3,7 +3,6 @@ package com.estonianport.unique.controller
 import com.estonianport.unique.mapper.PiscinaMapper
 import com.estonianport.unique.dto.response.CustomResponse
 import com.estonianport.unique.service.PiscinaService
-import com.estonianport.unique.service.UsuarioService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.CrossOrigin
@@ -63,8 +62,17 @@ class PiscinaController {
         return ResponseEntity.status(200).body(
             CustomResponse(
                 message = "Lecturas de la piscina obtenida correctamente",
-                // TODO Aca no se si harias un mapper, despues acomodalo como mejor creas yo suelo hacerlo asi
                 data = piscinaService.getLecturasPiscina(piscinaId)
+            )
+        )
+    }
+
+    @GetMapping("programacion/{piscinaId}")
+    fun getProgramacionPiscina(@PathVariable piscinaId: Long): ResponseEntity<CustomResponse> {
+        return ResponseEntity.status(200).body(
+            CustomResponse(
+                message = "Programaciones de la piscina obtenidas correctamente",
+                data = PiscinaMapper.buildPiscinaProgramacionResponseDto(piscinaService.findById(piscinaId))
             )
         )
     }

--- a/src/main/kotlin/com/estonianport/unique/dto/response/LecturaConErrorResponseDto.kt
+++ b/src/main/kotlin/com/estonianport/unique/dto/response/LecturaConErrorResponseDto.kt
@@ -2,7 +2,7 @@ package com.estonianport.unique.dto.response
 
 import java.time.LocalDateTime
 
-data class LecturaConErrorDto(
+data class LecturaConErrorResponseDto(
     val id: Long,
     val fecha: LocalDateTime,
     val ph: Double?,

--- a/src/main/kotlin/com/estonianport/unique/dto/response/PiscinaProgramacionResponseDto.kt
+++ b/src/main/kotlin/com/estonianport/unique/dto/response/PiscinaProgramacionResponseDto.kt
@@ -1,0 +1,10 @@
+package com.estonianport.unique.dto.response
+
+data class PiscinaProgramacionResponseDto (
+    val id: String,
+    val nombre: String,
+    val direccion: String,
+    val volumen: String,
+    val programacionLuces: List<ProgramacionResponseDto>,
+    val programacionFiltrado: List<ProgramacionResponseDto>
+)

--- a/src/main/kotlin/com/estonianport/unique/dto/response/PiscinaResumenResponseDto.kt
+++ b/src/main/kotlin/com/estonianport/unique/dto/response/PiscinaResumenResponseDto.kt
@@ -1,7 +1,7 @@
 package com.estonianport.unique.dto.response
 
 data class PiscinaResumenResponseDto (
-    val id : String,
+    val id: String,
     val nombre: String,
     val direccion: String,
     val volumen: String,

--- a/src/main/kotlin/com/estonianport/unique/dto/response/ProgramacionResponseDto.kt
+++ b/src/main/kotlin/com/estonianport/unique/dto/response/ProgramacionResponseDto.kt
@@ -1,0 +1,9 @@
+package com.estonianport.unique.dto.response
+
+data class ProgramacionResponseDto (
+    val id: String,
+    val horaInicio: String,
+    val horaFin: String,
+    val dias: List<String>,
+    val estaActivo: Boolean
+)

--- a/src/main/kotlin/com/estonianport/unique/mapper/PiscinaMapper.kt
+++ b/src/main/kotlin/com/estonianport/unique/mapper/PiscinaMapper.kt
@@ -2,6 +2,7 @@ package com.estonianport.unique.mapper
 
 import com.estonianport.unique.dto.response.PiscinaEquipamientoResponseDto
 import com.estonianport.unique.dto.response.PiscinaListResponseDto
+import com.estonianport.unique.dto.response.PiscinaProgramacionResponseDto
 import com.estonianport.unique.dto.response.PiscinaResumenResponseDto
 import com.estonianport.unique.model.Piscina
 
@@ -27,7 +28,7 @@ object PiscinaMapper {
             entradaAgua = piscina.entradaAgua.map { it.toString() }.toList(),
             funcionActiva = piscina.funcionActiva.map { it.toString() }.toList(),
             sistemasGermicidas = piscina.sistemaGermicida.map { it.toString() }.toList(),
-            calefaccion = piscina.tieneCalefaccion()
+            calefaccion = piscina.tieneCalefaccion(),
         )
     }
 
@@ -49,6 +50,17 @@ object PiscinaMapper {
                     it
                 )
             }.toList(),
+        )
+    }
+
+    fun buildPiscinaProgramacionResponseDto(piscina: Piscina): PiscinaProgramacionResponseDto {
+        return PiscinaProgramacionResponseDto(
+            id = piscina.id.toString(),
+            nombre = piscina.nombre,
+            direccion = piscina.direccion,
+            volumen = piscina.volumen.toString(),
+            programacionLuces = piscina.programacionLuces.map { ProgramacionMapper.buildProgramacionResponseDto(it) }.toList(),
+            programacionFiltrado = piscina.programacionFiltrado.map { ProgramacionMapper.buildProgramacionResponseDto(it) }.toList()
         )
     }
 }

--- a/src/main/kotlin/com/estonianport/unique/mapper/ProgramacionMapper.kt
+++ b/src/main/kotlin/com/estonianport/unique/mapper/ProgramacionMapper.kt
@@ -1,0 +1,20 @@
+package com.estonianport.unique.mapper
+
+import com.estonianport.unique.dto.response.ProgramacionResponseDto
+import com.estonianport.unique.model.Programacion
+
+object ProgramacionMapper {
+
+    fun buildProgramacionResponseDto(
+        programacion: Programacion
+    ): ProgramacionResponseDto {
+        return ProgramacionResponseDto(
+            id = programacion.id.toString(),
+            horaInicio = programacion.horaInicio.toString(),
+            horaFin = programacion.horaFin.toString(),
+            dias = programacion.dias.map { it.toString() },
+            estaActivo = programacion.estaActivo
+        )
+    }
+
+}

--- a/src/main/kotlin/com/estonianport/unique/repository/PiscinaRepository.kt
+++ b/src/main/kotlin/com/estonianport/unique/repository/PiscinaRepository.kt
@@ -1,6 +1,6 @@
 package com.estonianport.unique.repository
 
-import com.estonianport.unique.dto.response.LecturaConErrorDto
+import com.estonianport.unique.dto.response.LecturaConErrorResponseDto
 import com.estonianport.unique.model.Piscina
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -59,5 +59,5 @@ interface PiscinaRepository : JpaRepository<Piscina, Int> {
             ORDER BY fecha""",
         nativeQuery = true
     )
-    fun findTodasLecturasConError(piscinaId: Long): List<LecturaConErrorDto>
+    fun findTodasLecturasConError(piscinaId: Long): List<LecturaConErrorResponseDto>
 }

--- a/src/main/kotlin/com/estonianport/unique/service/PiscinaService.kt
+++ b/src/main/kotlin/com/estonianport/unique/service/PiscinaService.kt
@@ -1,6 +1,6 @@
 package com.estonianport.unique.service
 
-import com.estonianport.unique.dto.response.LecturaConErrorDto
+import com.estonianport.unique.dto.response.LecturaConErrorResponseDto
 import com.estonianport.unique.model.Piscina
 import com.estonianport.unique.repository.PiscinaRepository
 import org.springframework.stereotype.Service
@@ -19,7 +19,7 @@ class PiscinaService(private val piscinaRepository: PiscinaRepository, private v
             ?: throw IllegalArgumentException("Piscina no encontrada con ID: $piscinaId")
     }
 
-    fun getLecturasPiscina(piscinaId: Long): List<LecturaConErrorDto> {
+    fun getLecturasPiscina(piscinaId: Long): List<LecturaConErrorResponseDto> {
         return piscinaRepository.findTodasLecturasConError(piscinaId)
     }
 


### PR DESCRIPTION
Seba, dejo este PR cortito donde lo que hice fue agregar el ultimo endpoint (creo) que faltaba para la vista de usuario. Básicamente trae las información de las programaciones de la piscina, tanto de luces como de filtrado. Al principio lo había agregado al endpoint de resumen, pero me pareció que usar el mismo endpoint, si bien reducía código, era traer información irrelevante para esa sección.

Con respecto al TODO del mapper de lecturas que me dejaste, comencé a implementarlo pero me di cuenta que en la query que hiciste en el repo se agrega la variable esError que no esta en el modelo, sino que es un dato que obtiene de la bbdd. Por esa razón no puedo trabajar con mapper y la serializacion la hace directo como lo hiciste vos.
Entiendo que no hay problema que sea así, la idea del mapper es ser el objeto "global" que se encarga de la serialización desligando al service y a cualquier método que este en el. La única manera que se me ocurre para poder trabajar con un mapper seria trabajar el esError desde el back y no desde la bbdd, osea teniendo algun metodo que detecte si la lectura fue erronea. De esa manera la clase Lectura si podria tener una variable esError y ahi si, el mapper funcionaria.
De todos modos, creo que eso lo dejaria para futuros refactors. 